### PR TITLE
Fix incorrect labeling of legal moves

### DIFF
--- a/src/com/mrjaffesclass/othello/Board.java
+++ b/src/com/mrjaffesclass/othello/Board.java
@@ -152,7 +152,7 @@ public class Board
     } else if ((this.getSquare(newPosition).getStatus() == Constants.EMPTY) && (count == 0)) {
       // If empty space AND adjacent to position then not legal
       return false;
-    } else if (!player.isThisPlayer(this.getSquare(newPosition).getStatus())) {
+    } else if (!player.isThisPlayer(this.getSquare(newPosition).getStatus()) && this.getSquare(newPosition).getStatus() != Constants.EMPTY) {
       // If space has opposing player then move to next space in same direction
       return step(player, newPosition, direction, count+1);
     } else if (player.isThisPlayer(this.getSquare(newPosition).getStatus())) {


### PR DESCRIPTION
Before, there were edge cases that caused positions with empty spaces between them to be treated as if they had the opponent's color in them, thus making moves that were illegal legal. If there was a hypothetical column with W being white, E empty, and B black:
E
B
E
W
The upper E would be marked as a valid move by white, despite an empty space between it and the next white space. By checking if the space is empty, it avoids the problem.